### PR TITLE
Cater for character encodings other than ASCII

### DIFF
--- a/src/org/phpsrc/eclipse/pti/core/php/source/PHPSourceFile.java
+++ b/src/org/phpsrc/eclipse/pti/core/php/source/PHPSourceFile.java
@@ -43,7 +43,7 @@ public class PHPSourceFile implements ISourceFile {
 		lineStartTabCount = new ArrayList<Integer>();
 
 		InputStreamReader isr;
-		isr = new InputStreamReader(file.getContents());
+		isr = new InputStreamReader(file.getContents(), ResourcesPlugin.getEncoding());
 
 		int last = -1;
 		int i = 0;


### PR DESCRIPTION
Use workspace character encoding setting while reading files.
