### PR TITLE
Fix for UTF-8 source code

### DIFF
--- a/src/org/phpsrc/eclipse/pti/core/php/source/PHPSourceFile.java
+++ b/src/org/phpsrc/eclipse/pti/core/php/source/PHPSourceFile.java
@@ -43,7 +43,7 @@ public class PHPSourceFile implements ISourceFile {
 		lineStartTabCount = new ArrayList<Integer>();
 
 		InputStreamReader isr;
-		isr = new InputStreamReader(file.getContents());
+		isr = new InputStreamReader(file.getContents(), file.getCharset());
 
 		int last = -1;
 		int i = 0;


### PR DESCRIPTION
When reporting problem in eclipse code editor from CodeSniffer if there are UTF-8 characters the starting offset to display where is the error is miscalculated. It is just needed to correctly set the charset to the InputStreamReader...
